### PR TITLE
Courses faculty

### DIFF
--- a/lib/school/courses/course.ex
+++ b/lib/school/courses/course.ex
@@ -20,6 +20,41 @@ defmodule School.Courses.Course do
             | Fourth.t()
         }
 
+  @course_fields [
+    :course_name,
+    :code,
+    :semester,
+    :description,
+    :teacher_id,
+    :faculty
+  ]
+
+  @required_fields [:course_name, :code, :teacher_id, :semester, :faculty]
+
+  @engineering_branches [
+    "civil",
+    "chemical",
+    "mechanical",
+    "electrical",
+    "industrial",
+    "computer"
+  ]
+
+  @art_branches [
+    "creative arts",
+    "writing",
+    "philosophy",
+    "humanities"
+  ]
+
+  @science_branches [
+    "physics",
+    "biology",
+    "chemistry",
+    "math",
+    "anatomy",
+    "statistics"
+  ]
   @doc """
   Schema for the courses, with the fields specified, and a many to one relationship with the teachers and many to many
   relationship with the students.
@@ -65,16 +100,9 @@ defmodule School.Courses.Course do
       end
 
     course
-    |> cast(attrs, [
-      :course_name,
-      :code,
-      :semester,
-      :description,
-      :teacher_id,
-      :faculty
-    ])
-    |> validate_required([:course_name, :code, :teacher_id, :semester, :faculty])
-    |> branch_changeset(attrs)
+    |> cast(attrs, @course_fields)
+    |> validate_required(@required_fields)
+    |> maybe_cast_branch(attrs)
     |> cast_polymorphic_embed(:metadata, required: true)
     |> foreign_key_constraint(:teacher_id)
     |> IO.inspect()
@@ -87,47 +115,28 @@ defmodule School.Courses.Course do
     Map.put(attrs, "metadata", metadata)
   end
 
-  def branch_changeset(changeset, attrs) do
+  def maybe_cast_branch(changeset, attrs) do
     case get_field(changeset, :faculty) do
-      :history ->
-        changeset
-
-      :law ->
-        changeset
-
       :engineering ->
-        cast(changeset, attrs, [:branches])
-        |> validate_inclusion(:branches, [
-          "civil",
-          "chemical",
-          "mechanical",
-          "electrical",
-          "industrial",
-          "computer"
-        ])
+        changeset
+        |> cast(attrs, [:branches])
+        |> validate_inclusion(:branches, @engineering_branches)
         |> validate_required(:branches, message: "Please enter an engineering faculty branch")
 
       :art ->
-        cast(changeset, attrs, [:branches])
-        |> validate_inclusion(:branches, [
-          "creative arts",
-          "writing",
-          "philosophy",
-          "humanities"
-        ])
+        changeset
+        |> cast(attrs, [:branches])
+        |> validate_inclusion(:branches, @art_branches)
         |> validate_required(:branches, message: "Please enter an art faculty branch")
 
       :science ->
-        cast(changeset, attrs, [:branches])
-        |> validate_inclusion(:branches, [
-          "physics",
-          "biology",
-          "chemistry",
-          "math",
-          "anatomy",
-          "statistics"
-        ])
+        changeset
+        |> cast(attrs, [:branches])
+        |> validate_inclusion(:branches, @science_branches)
         |> validate_required(:branches, message: "Please enter a science faculty branch")
+
+      _ ->
+        changeset
     end
   end
 end

--- a/lib/school/courses/course.ex
+++ b/lib/school/courses/course.ex
@@ -71,11 +71,10 @@ defmodule School.Courses.Course do
       :semester,
       :description,
       :teacher_id,
-      :faculty,
-      :branches
+      :faculty
     ])
     |> validate_required([:course_name, :code, :teacher_id, :semester, :faculty])
-    |> branch_changeset()
+    |> branch_changeset(attrs)
     |> cast_polymorphic_embed(:metadata, required: true)
     |> foreign_key_constraint(:teacher_id)
     |> IO.inspect()
@@ -88,16 +87,17 @@ defmodule School.Courses.Course do
     Map.put(attrs, "metadata", metadata)
   end
 
-  def branch_changeset(changeset) do
+  def branch_changeset(changeset, attrs) do
     case get_field(changeset, :faculty) do
       :history ->
-        validate_inclusion(changeset, :branches, [nil])
+        changeset
 
       :law ->
-        validate_inclusion(changeset, :branches, [nil])
+        changeset
 
       :engineering ->
-        validate_inclusion(changeset, :branches, [
+        cast(changeset, attrs, [:branches])
+        |> validate_inclusion(:branches, [
           "civil",
           "chemical",
           "mechanical",
@@ -108,7 +108,8 @@ defmodule School.Courses.Course do
         |> validate_required(:branches, message: "Please enter an engineering faculty branch")
 
       :art ->
-        validate_inclusion(changeset, :branches, [
+        cast(changeset, attrs, [:branches])
+        |> validate_inclusion(:branches, [
           "creative arts",
           "writing",
           "philosophy",
@@ -117,7 +118,8 @@ defmodule School.Courses.Course do
         |> validate_required(:branches, message: "Please enter an art faculty branch")
 
       :science ->
-        validate_inclusion(changeset, :branches, [
+        cast(changeset, attrs, [:branches])
+        |> validate_inclusion(:branches, [
           "physics",
           "biology",
           "chemistry",

--- a/lib/school/courses/faculty/history.ex
+++ b/lib/school/courses/faculty/history.ex
@@ -1,0 +1,8 @@
+defmodule School.Courses.Faculty.History do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+  end
+end

--- a/lib/school/courses/faculty/history.ex
+++ b/lib/school/courses/faculty/history.ex
@@ -1,8 +1,0 @@
-defmodule School.Courses.Faculty.History do
-  use Ecto.Schema
-  import Ecto.Changeset
-
-  @primary_key false
-  embedded_schema do
-  end
-end

--- a/priv/repo/migrations/20220420090605_add_faculty_and_branches_to_courses.exs
+++ b/priv/repo/migrations/20220420090605_add_faculty_and_branches_to_courses.exs
@@ -1,0 +1,10 @@
+defmodule School.Repo.Migrations.AddFacultyAndBranchesToCourses do
+  use Ecto.Migration
+
+  def change do
+    alter table(:courses) do
+      add :faculty, :string, null: false
+      add :branches, :string
+    end
+  end
+end


### PR DESCRIPTION
Added two new fields to the courses table, faculty field and branches fields.
a Faculty field can be one of the following (History, Engineering, Art, Science and Law)
the Branches field has to correspond to the Faculty field by limiting the choices of the branches based on the faculty.
`Changeset.validate_inclusion(changeset, field, data, opts \\ [])` is used to ensure that the data entered in the branches field is validated against the faculty.